### PR TITLE
Save multiple databases to individual files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+*.resp

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 *.resp
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ redis_dump_rust [OPTIONS]
 | `-h, --host`        | Redis server address              | `127.0.0.1`       |
 | `-p, --port`        | Redis server port                 | `6379`            |
 | `-a, --auth`        | Redis password                    | -                 |
-| `-d, --db`          | Database number                   | All               |
+| `-d, --db`          | Database number                   | All (with data)   |
 | `-f, --filter`      | Key pattern filter                | `*`               |
-| `-o, --output`      | Output file                       | `redis_dump.txt`  |
+| `-o, --output`      | Output file                       | `redis_dump.resp` |
 | `-b, --batch-size`  | Batch size for operations         | `1000`            |
 | `-w, --workers`     | Number of parallel workers        | `10`              |
 | `-s, --silent`      | Silent mode                       | `false`           |
@@ -38,4 +38,14 @@ For more help:
 ```bash
 redis_dump_rust --help
 ```
+
+### Multi-database output
+
+When `--db` is omitted and multiple databases contain keys, the tool dumps each database into a
+separate file. The file name is derived from `--output` by inserting `_db{N}` before the file
+extension, for example:
+
+- `redis_dump.resp` -> `redis_dump_db0.resp`, `redis_dump_db3.resp`
+
+If only one database has keys, the original output filename is used without a suffix.
 

--- a/example/populate_redis.sh
+++ b/example/populate_redis.sh
@@ -27,8 +27,15 @@ for i in $(seq 1 $MAX_RETRIES); do
   sleep $RETRY_INTERVAL
 done
 
-# Populate Redis with 1M string keys
-echo "Populating Redis with 1M string keys..."
-seq 1 1000000 | awk '{print "SETEX string_key_" $1 " 3600 value_" $1}' | docker exec -i ${REDIS_CONTAINER} redis-cli --pipe
+# Populate multiple Redis databases with sample data
+echo "Populating Redis with sample data across multiple databases..."
+{
+  echo "SELECT 0"
+  seq 1 1000000 | awk '{print "SETEX string_key_db0_" $1 " 3600 value_" $1}'
+  echo "SELECT 1"
+  seq 1 300000 | awk '{print "SETEX string_key_db1_" $1 " 3600 value_" $1}'
+  echo "SELECT 2"
+  seq 1 200000 | awk '{print "SETEX string_key_db2_" $1 " 3600 value_" $1}'
+} | docker exec -i ${REDIS_CONTAINER} redis-cli --pipe
 
 echo "Done! Redis has been populated successfully."

--- a/fragments/1770656365229.feature
+++ b/fragments/1770656365229.feature
@@ -1,0 +1,1 @@
+Dump multiple Redis databases when `--db` is omitted, writing per-db output files.Adiciona contexto do assistenter virtual de gestão.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -49,7 +49,7 @@ pub fn parse_cli() -> DumpConfig {
                 .short('d')
                 .long("db")
                 .value_name("DB")
-                .help("Database number (default: all)"),
+                .help("Database number (if omitted, dumps all databases with data)"),
         )
         .arg(
             Arg::new("filter")
@@ -64,7 +64,7 @@ pub fn parse_cli() -> DumpConfig {
                 .short('o')
                 .long("output")
                 .value_name("FILE")
-                .help("Output file")
+                .help("Output file (per-db dumps add _db{N} before the extension)")
                 .default_value("redis_dump.resp"),
         )
         .arg(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,6 +20,22 @@ pub enum OutputFormat {
     Resp,
 }
 
+pub fn resolve_output_path(base_path: &str, db: u8) -> String {
+    use std::path::Path;
+
+    let path = Path::new(base_path);
+    let stem = path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or(base_path);
+    let ext = path.extension().and_then(|value| value.to_str());
+
+    match ext {
+        Some(ext) => format!("{stem}_db{db}.{ext}"),
+        None => format!("{stem}_db{db}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -92,6 +108,18 @@ mod tests {
 
         assert_eq!(format!("{:?}", resp_format), "Resp");
         assert_eq!(format!("{:?}", commands_format), "Commands");
+    }
+
+    #[test]
+    fn test_resolve_output_path_with_extension() {
+        let result = resolve_output_path("redis_dump.resp", 3);
+        assert_eq!(result, "redis_dump_db3.resp");
+    }
+
+    #[test]
+    fn test_resolve_output_path_without_extension() {
+        let result = resolve_output_path("redis_dump", 0);
+        assert_eq!(result, "redis_dump_db0");
     }
 
     #[test]

--- a/src/redis_ops/connection.rs
+++ b/src/redis_ops/connection.rs
@@ -55,3 +55,28 @@ pub(crate) async fn scan_keys(
 
     Ok(all_keys)
 }
+
+pub(crate) async fn discover_databases(
+    connection: &mut redis::aio::MultiplexedConnection,
+) -> Result<Vec<u8>> {
+    let info: String = redis::cmd("INFO")
+        .arg("keyspace")
+        .query_async(connection)
+        .await?;
+    let mut databases = Vec::new();
+
+    for line in info.lines() {
+        if let Some(rest) = line.strip_prefix("db") {
+            let mut parts = rest.splitn(2, ':');
+            if let Some(db_str) = parts.next() {
+                if let Ok(db) = db_str.parse::<u8>() {
+                    databases.push(db);
+                }
+            }
+        }
+    }
+
+    databases.sort_unstable();
+    databases.dedup();
+    Ok(databases)
+}


### PR DESCRIPTION
Implement functionality to save multiple Redis databases into separate output files when the `--db` option is omitted. Update documentation and examples to reflect these changes, and ensure the `.gitignore` is updated accordingly.